### PR TITLE
Update ESLint to v4.2.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,6 +98,8 @@ module.exports = {
         ],
         "eol-last": "error",
         "eqeqeq": "error",
+        "for-direction": "error",
+        "getter-return": "error",
         "indent": [
             "error",
             4,
@@ -137,6 +139,7 @@ module.exports = {
             "always"
         ],
         "semi-spacing": "error",
+        "semi-style": "error",
         "space-before-blocks": "error",
         "space-before-function-paren": [
             "error",
@@ -149,6 +152,7 @@ module.exports = {
             "error",
             "function"
         ],
+        "switch-colon-spacing": "error",
         "wrap-iife": [
             "error",
             "any"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   "author": "ama-ch <amach97@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "eslint": ">= 3"
+    "eslint": ">= 4.2.0"
   }
 }


### PR DESCRIPTION
This PR is to update the peerDependencies of `ESLint` to v4.2.0.
(v4.2.0 is the version added `getter-return` rule)

In addition to that, I've enabled the following rules.
What do you think?

* [for-direction](https://eslint.org/docs/rules/for-direction)
* [getter-return](https://eslint.org/docs/rules/getter-return)
* [semi-style](https://eslint.org/docs/rules/semi-style)
* [switch-colon-spacing](https://eslint.org/docs/rules/switch-colon-spacing)

I'd like to update the ESLInt version to latest(v4.19.1). 
But I didn't do that because of the users installing ESLint globally. it might be hard to update ESLint to the latest for those users.